### PR TITLE
fix: reject promises when ipc send fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.DS_Store

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { connect } from "https://deno.land/x/namedpipe@0.0.2/mod.ts";
+export { connect } from "https://deno.land/x/namedpipe@0.0.3/mod.ts";

--- a/src/conn.ts
+++ b/src/conn.ts
@@ -108,7 +108,7 @@ export class DiscordIPC {
         args,
         nonce,
         evt,
-      });
+      }).catch(reject);
     });
   }
 
@@ -120,7 +120,9 @@ export class DiscordIPC {
   login(clientID: string) {
     return new Promise<ReadyEventPayload>((resolve, reject) => {
       this.#readyHandle = { resolve, reject };
-      this.send(OpCode.HANDSHAKE, { v: "1", client_id: clientID });
+      this.send(OpCode.HANDSHAKE, { v: "1", client_id: clientID }).catch(
+        reject,
+      );
     });
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -38,6 +38,10 @@ export async function findIPC(id = 0): Promise<Deno.Conn> {
       });
     }
   } catch (_) {
-    return findIPC(id + 1);
+    if (id < 10) {
+      return findIPC(id + 1);
+    } else {
+      throw new Error("Could not connect");
+    }
   }
 }


### PR DESCRIPTION
It was currently impossible to catch the `Broken pipe` error when setting an activity just after the user closed his Discord client. Rejecting the promises in `sendCommand` fixes it.