### PR TITLE
chore: bump namedpipe version

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { connect } from "https://deno.land/x/namedpipe@0.0.3/mod.ts";
+export { connect } from "https://deno.land/x/namedpipe@0.1.0/mod.ts";


### PR DESCRIPTION
fixes ts error on latest deno version