### PR TITLE
fix: make timestamps fields optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,8 +14,8 @@ export interface Activity {
     size?: number;
   };
   timestamps?: {
-    start: number;
-    end: number;
+    start?: number;
+    end?: number;
   };
   secrets?: {
     match?: string;


### PR DESCRIPTION
Activity timestamps fields are optional according to [the documentation](https://discord.com/developers/docs/topics/gateway#activity-object-activity-timestamps).