### PR TITLE
feat: allow setting activity type

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { DiscordIPC, PacketIPCEvent } from "./conn.ts";
 import type {
   Activity,
+  ActivityType,
   ApplicationPayload,
   AuthenticateResponsePayload,
   ChannelPayload,
@@ -95,7 +96,7 @@ export class Client {
    */
   setActivity(activity?: Activity) {
     return this.ipc!.sendCommand<
-      Activity & { application_id: string; type: number }
+      Activity & { application_id: string; type: ActivityType }
     >(
       "SET_ACTIVITY",
       {

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,9 @@ export class Client {
   get userTag() {
     return this.user === undefined
       ? undefined
-      : `${this.user.username}${this.user.discriminator === "0" ? "" : `#${this.user.discriminator}`}`;
+      : `${this.user.username}${
+        this.user.discriminator === "0" ? "" : `#${this.user.discriminator}`
+      }`;
   }
 
   get authenticated() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 // deno-lint-ignore-file camelcase
 
 export interface Activity {
+  type?: ActivityType;
   details?: string;
   state?: string;
   assets?: {
@@ -26,6 +27,15 @@ export interface Activity {
     label?: string;
     url?: string;
   }[];
+}
+
+export enum ActivityType {
+  PLAYING,
+  STREAMING,
+  LISTENING,
+  WATCHING,
+  CUSTOM,
+  COMPETING,
 }
 
 export enum OpCode {


### PR DESCRIPTION
Custom RPC activity types are now supported on recent versions of the Discord client

https://discord.com/developers/docs/change-log#supported-activity-types-for-setactivity
https://discord.com/developers/docs/topics/rpc#setactivity-set-activity-argument-structure